### PR TITLE
fixed indentation issues with block comments

### DIFF
--- a/lib/beautify-js.js
+++ b/lib/beautify-js.js
@@ -1135,7 +1135,6 @@ function js_beautify(js_source_text, options) {
           if (lines.length > 1) {
             // multiline comment block starts with a new line
             print_newline();
-            trim_output();
           }
           else {
             // single-line /* comment */ stays where it is
@@ -1143,8 +1142,8 @@ function js_beautify(js_source_text, options) {
           }
         
           for (i = 0; i < lines.length; i += 1) {
-            output.push(lines[i]);
-            output.push('\n');
+            output.push(lines[i].replace(/^\s\s*\*|\s\s*\*$/, ' *')); // align stars
+            print_newline();
           }
         }
 


### PR DESCRIPTION
Hi there!

I fixed something that was bothering me with node-beautify.
The first line of regular comment blocks wouldn't get indented.
Also starred comments were only aligned if the block was opened using the jsdoc signifier (`/**`) but it should also work for regular comment blocks.

For better understanding, check the examples.
**INPUT:**

``` js
    /*
     * ----------------------------------------------------------------
                * starred commentblocks
     * ----------------------------------------------------------------
     */

    var foo = 1;/* inline comments */

    var bar = 1;/*
        and
        just
    normal comment blocks
     */
```

**CURRENT OTPUT:**

``` js
/*
     * ----------------------------------------------------------------
                * starred commentblocks
     * ----------------------------------------------------------------
     */

        var foo = 1; /* inline comments */

        var bar = 1;
/*
        and
        just
    normal comment blocks
     */
```

**OUTPUT AFTER FIX:**

``` js
        /*
         * ----------------------------------------------------------------
         * starred commentblocks
         * ----------------------------------------------------------------
         */

        var foo = 1; /* inline comments */

        var bar = 1;
        /*
                and
                just
            normal comment blocks
         */
```

I ran the tests and they don't fail.

Also I noticed that for some reason when you run `npm install node-beautify` it installs verion `0.0.2`, not `0.0.4`, as noted in the package.json.

So after pulling this fix and maybe bumping the version number you might want to consider tagging the last commit using `git tag v0.0.5` - that might help.

best regards,
J
